### PR TITLE
Abstract return object instead of raising errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,6 @@ Style/HashSyntax:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Metrics/MethodLength:
+  CountAsOne: ['array', 'heredoc', 'method_call']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+
+### Changed
+
+* All public services now return a `Return` class that contains the actual data or an error object. This replaces the throwing of errors for control-flow.
+
+## [0.2.1 - 0.2.4]
+
+### Fixed
+
+* Boilerplate bugs
+
 ## [0.2.0] - 2023-06-15
 
 ### Added

--- a/lib/squake/calculation.rb
+++ b/lib/squake/calculation.rb
@@ -14,7 +14,7 @@ module Squake
         items: T::Array[T.any(Squake::Model::Items::BaseType, T::Hash[T.any(String, Symbol), T.untyped])],
         carbon_unit: String,
         expand: T::Array[String],
-      ).returns(Squake::Model::Carbon)
+      ).returns(Squake::Return[Squake::Model::Carbon])
     end
     def self.create(client:, items:, carbon_unit: 'gram', expand: [])
       # @TODO: add typed objects for all possible items. Until then, we allow either a Hash or a T::Struct
@@ -31,11 +31,19 @@ module Squake
           expand: expand,
         },
       )
-      raise Squake::APIError.new(response: result) unless result.success?
 
-      Squake::Model::Carbon.from_api_response(
-        T.cast(result.body, T::Hash[Symbol, T.untyped]),
-      )
+      if result.success?
+        carbon = Squake::Model::Carbon.from_api_response(
+          T.cast(result.body, T::Hash[Symbol, T.untyped]),
+        )
+        Return.new(result: carbon)
+      else
+        error = Squake::Errors::APIErrorResult.new(
+          code: :"api_error_#{result.code}",
+          detail: result.error_message,
+        )
+        Return.new(errors: [error])
+      end
     end
   end
 end

--- a/lib/squake/calculation_with_pricing.rb
+++ b/lib/squake/calculation_with_pricing.rb
@@ -16,7 +16,7 @@ module Squake
         currency: String,
         carbon_unit: String,
         expand: T::Array[String],
-      ).returns(Squake::Model::Pricing)
+      ).returns(Squake::Return[Squake::Model::Pricing])
     end
     def self.quote(client:, items:, product:, currency: 'EUR', carbon_unit: 'gram', expand: [])
       # @TODO: add typed objects for all possible items. Until then, we allow either a Hash or a T::Struct
@@ -35,11 +35,19 @@ module Squake
           expand: expand,
         },
       )
-      raise Squake::APIError.new(response: result) unless result.success?
 
-      Squake::Model::Pricing.from_api_response(
-        T.cast(result.body, T::Hash[Symbol, T.untyped]),
-      )
+      if result.success?
+        pricing = Squake::Model::Pricing.from_api_response(
+          T.cast(result.body, T::Hash[Symbol, T.untyped]),
+        )
+        Return.new(result: pricing)
+      else
+        error = Squake::Errors::APIErrorResult.new(
+          code: :"api_error_#{result.code}",
+          detail: result.error_message,
+        )
+        Return.new(errors: [error])
+      end
     end
   end
 end

--- a/lib/squake/errors/api_error_result.rb
+++ b/lib/squake/errors/api_error_result.rb
@@ -1,0 +1,22 @@
+# typed: strict
+# frozen_string_literal: true
+
+require_relative 'api_error_source'
+
+module Squake
+  module Errors
+    #
+    # https://jsonapi.org/format/#errors
+    #
+    # > Error objects MUST be returned as an array keyed by errors in the top level of a JSON:API document.
+    #
+    class APIErrorResult < T::Struct
+      const :code, Symbol # An application-specific error code
+
+      # A human-readable explanation specific to this occurrence of the problem.
+      # Like title, this field's value can be localized.
+      const :detail, T.nilable(String)
+      const :source, T.nilable(APIErrorSource)
+    end
+  end
+end

--- a/lib/squake/errors/api_error_source.rb
+++ b/lib/squake/errors/api_error_source.rb
@@ -1,0 +1,12 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Squake
+  module Errors
+    class APIErrorSource < T::Struct
+      const :attribute, T.any(Symbol, String)
+      const :model, T.nilable(String), default: nil
+      const :id, T.nilable(String), default: nil # external reference if given
+    end
+  end
+end

--- a/lib/squake/return.rb
+++ b/lib/squake/return.rb
@@ -1,0 +1,64 @@
+# typed: strict
+# frozen_string_literal: true
+
+require_relative 'errors/api_error_result'
+
+module Squake
+  class Return
+    class Failure < StandardError; end
+
+    FAILURE_MSG_NO_ARGS = 'Must provide either a result or errors'
+    FAILURE_MSG_BOTH_ARGS = 'Cannot provide both a result and errors'
+    FAILURE_ERRORS_CALLED_WHEN_SUCCESS = 'Cannot call errors when result is present'
+
+    extend T::Sig
+    extend T::Generic
+
+    Error = type_member { { fixed: Errors::APIErrorResult } }
+    Result = type_member { { upper: Object } }
+
+    sig { params(result: T.nilable(Result), errors: T.nilable(T::Array[Error])).void }
+    def initialize(result: nil, errors: nil)
+      raise Failure, FAILURE_MSG_NO_ARGS if result.nil? && errors.nil?
+      raise Failure, FAILURE_MSG_BOTH_ARGS if present?(result) && present?(errors)
+
+      @result = result
+      @errors = errors
+    end
+
+    sig { returns(T::Boolean) }
+    def success?
+      present?(@result)
+    end
+
+    sig { returns(T::Boolean) }
+    def failed?
+      !success?
+    end
+
+    sig { returns(T::Array[Error]) }
+    def errors
+      raise Failure, FAILURE_ERRORS_CALLED_WHEN_SUCCESS if success?
+
+      T.must(@errors)
+    end
+
+    sig { returns(Result) }
+    def result
+      raise Failure, @errors&.map(&:serialize) if failed?
+
+      T.must(@result)
+    end
+
+    # courtesy to Rails, see: https://api.rubyonrails.org/v7.0.5/classes/Object.html
+    sig { params(object: T.untyped).returns(T::Boolean) }
+    private def blank?(object)
+      object.respond_to?(:empty?) ? !!object.empty? : !object
+    end
+
+    sig { params(object: T.untyped).returns(T::Boolean) }
+    private def present?(object)
+      !blank?(object)
+    end
+  end
+end

--- a/lib/squake/version.rb
+++ b/lib/squake/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Squake
-  VERSION = '0.2.4'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
#### Summary

⚠️ this is a breaking change to the library.

Instead of raising exceptions, a abstract "Return" object is returned from all services. This object encapsules either a result or errors and knows 
wether the service failed or succeeded.

- abstract return object
- all endpoints return "return" object instead of raising an error
- abstract error klass
- breaking change
- Update CHANGELOG.md
- update readme
- relax rubocop method length


### Motiviation

Do not raise exceptions for control flow

Performance Impact: Raising and rescuing exceptions is much more computationally expensive than using standard control flow structures like if-else 
statements or case switches.

Readability and Maintainability: Using exceptions for control flow makes the code harder to understand and reason about. It makes the "happy path" of 
the code less obvious, and it may hide the real intentions of the code.

Error Handling Complexity: It can make actual error handling more difficult, as the code will be full of exceptions that aren't really exceptional. 
This can lead to "exception clutter" and it may make it harder to find and fix actual errors.

Semantics: Exceptions should represent exceptional, usually error, conditions. Using them for normal control flow goes against their intended purpose.

Brittleness: Exception-based control flow can lead to brittle code, as changes in the types of exceptions thrown (maybe due to changes in the 
libraries you're using) can cause unanticipated changes in your control flow.
