### PR TITLE
add Squake.configure to set up a global config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,6 @@ Style/HashSyntax:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Naming/BlockForwarding:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* added `Squake.configure`
+* introduced global config allowig to omit the `client` from all service calls
+
 ## [0.2.0] - 2023-06-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ You need a different API Key for production and sandbox.
 
 ## Usage
 
-Initialize the client:
+### Initialize the client
+
+either explicitly anywhere in the app
 
 ```ruby
 config = Squake::Config.new(
@@ -46,7 +48,21 @@ config = Squake::Config.new(
 client = Squake::Client.new(config: config)
 ```
 
-Calculate emissions
+or once globally in e.g. an initializer
+
+```ruby
+Squake.configure do |config|
+  config.api_key = ENV.fetch('SQUAKE_API_KEY') # optional if ENV var `SQUAKE_API_KEY` is set
+  config.sandbox_mode = true                   # set to `false` for production
+  config.keep_alive_timeout = 30               # optional, default: 30
+  config.logger = Logger.new($stdout)          # Set this to `Rails.logger` when using Rails
+  config.enforced_api_base = nil               # for testing to e.g. point to a local server
+end
+```
+
+If you have the API Key in an ENV var named `SQUAKE_API_KEY`, you don't need any further config.
+
+### Calculate emissions
 
 ```ruby
 items = [
@@ -71,7 +87,7 @@ carbon = Squake::Calculation.create(
 )
 ```
 
-Calculate emissions and include a price quote:
+### Calculate emissions and include a price quote
 
 ```ruby
 # Find all available item types and methodologies here:
@@ -100,7 +116,9 @@ pricing = Squake::CalculationWithPricing.quote(
 )
 ```
 
-Place a purchase order; by default the library injects a `SecureRandom.uuid` as `external_reference` to ensure idempotency, i.e. you can safely retry the request if it fails.
+### Place a purchase order
+
+by default the library injects a `SecureRandom.uuid` as `external_reference` to ensure idempotency, i.e. you can safely retry the request if it fails.
 
 ```ruby
 uuid = SecureRandom.uuid

--- a/lib/squake.rb
+++ b/lib/squake.rb
@@ -2,12 +2,36 @@
 # frozen_string_literal: true
 
 require 'sorbet-runtime'
+require 'sorbet'
 require 'oj'
 require 'net/http'
 
 Dir[File.join(__dir__, './**/*', '*.rb')].each { require(_1) }
 
-module Squake; end
+module Squake
+  class << self
+    extend T::Sig
+
+    sig { returns(T.nilable(Squake::Config)) }
+    attr_accessor :configuration
+
+    sig do
+      params(
+        _: T.proc.params(configuration: Squake::Config).void,
+      ).void
+    end
+    def configure(&_)
+      self.configuration ||= Squake::Config.new(
+        api_key: ENV.fetch('SQUAKE_API_KEY', nil),
+        keep_alive_timeout: ENV.fetch('SQUAKE_KEEP_ALIVE_TIMEOUT', 30).to_i,
+        sandbox_mode: ENV.fetch('SQUAKE_SANDBOX_MODE', 'true').casecmp?('true'),
+        enforced_api_base: ENV.fetch('SQUAKE_API_BASE', nil),
+      )
+
+      yield(T.must(configuration))
+    end
+  end
+end
 
 Oj.default_options = {
   mode: :compat, # required to dump hashes with symbol-keys

--- a/lib/squake/calculation.rb
+++ b/lib/squake/calculation.rb
@@ -10,13 +10,13 @@ module Squake
 
     sig do
       params(
-        client: Squake::Client,
         items: T::Array[T.any(Squake::Model::Items::BaseType, T::Hash[T.any(String, Symbol), T.untyped])],
         carbon_unit: String,
         expand: T::Array[String],
+        client: Squake::Client,
       ).returns(Squake::Model::Carbon)
     end
-    def self.create(client:, items:, carbon_unit: 'gram', expand: [])
+    def self.create(items:, carbon_unit: 'gram', expand: [], client: Squake::Client.new)
       # @TODO: add typed objects for all possible items. Until then, we allow either a Hash or a T::Struct
       items = items.map do |item|
         item.is_a?(T::Struct) ? item.serialize : item

--- a/lib/squake/calculation_with_pricing.rb
+++ b/lib/squake/calculation_with_pricing.rb
@@ -10,15 +10,15 @@ module Squake
 
     sig do
       params(
-        client: Squake::Client,
         items: T::Array[T.any(Squake::Model::Items::BaseType, T::Hash[T.any(String, Symbol), T.untyped])],
         product: String,
         currency: String,
         carbon_unit: String,
         expand: T::Array[String],
+        client: Squake::Client,
       ).returns(Squake::Model::Pricing)
     end
-    def self.quote(client:, items:, product:, currency: 'EUR', carbon_unit: 'gram', expand: [])
+    def self.quote(items:, product:, currency: 'EUR', carbon_unit: 'gram', expand: [], client: Squake::Client.new)
       # @TODO: add typed objects for all possible items. Until then, we allow either a Hash or a T::Struct
       items = items.map do |item|
         item.is_a?(T::Struct) ? item.serialize : item

--- a/lib/squake/client.rb
+++ b/lib/squake/client.rb
@@ -14,9 +14,9 @@ module Squake
       )
     end
 
-    sig { params(config: Squake::Config).void }
-    def initialize(config:)
-      @config = config
+    sig { params(config: T.nilable(Squake::Config)).void }
+    def initialize(config: nil)
+      @config = T.let(config || T.must(Squake.configuration), Squake::Config)
     end
 
     sig do
@@ -53,7 +53,7 @@ module Squake
     end
     private def execute_request(method:, path:, headers: {}, params: nil, api_base: nil, api_key: nil)
       api_base ||= @config.api_base
-      api_key ||= @config.api_key
+      api_key ||= T.must(@config.api_key)
 
       body_params = nil
       query_params = nil

--- a/lib/squake/config.rb
+++ b/lib/squake/config.rb
@@ -10,11 +10,11 @@ module Squake
     DEFAULT_BASE_URL = T.let('https://api.squake.earth', String)
     SANDBOX_BASE_URL = T.let('https://api.sandbox.squake.earth', String)
 
-    const :api_key, String
-    const :keep_alive_timeout, Integer, default: 30
-    const :logger, ::Logger, factory: -> { ::Logger.new($stdout) }
-    const :sandbox_mode, T::Boolean, default: true
-    const :enforced_api_base, T.nilable(String)
+    prop :api_key, T.nilable(String)
+    prop :keep_alive_timeout, Integer, default: 30
+    prop :logger, ::Logger, factory: -> { ::Logger.new($stdout) }
+    prop :sandbox_mode, T::Boolean, default: true
+    prop :enforced_api_base, T.nilable(String)
 
     sig { returns(String) }
     def api_base

--- a/lib/squake/products.rb
+++ b/lib/squake/products.rb
@@ -11,12 +11,12 @@ module Squake
 
     sig do
       params(
-        client: Squake::Client,
         locale: String,
         product_id: T.nilable(String),
+        client: Squake::Client,
       ).returns(T::Array[Squake::Model::Product])
     end
-    def self.get(client:, locale: DEFAULT_LOCALE, product_id: nil)
+    def self.get(locale: DEFAULT_LOCALE, product_id: nil, client: Squake::Client.new)
       path = product_id.nil? ? ENDPOINT : "#{ENDPOINT}/#{product_id}"
 
       result = client.call(

--- a/lib/squake/purchase.rb
+++ b/lib/squake/purchase.rb
@@ -11,16 +11,16 @@ module Squake
     # rubocop:disable Metrics/ParameterLists,  Layout/LineLength
     sig do
       params(
-        client: Squake::Client,
         pricing: String,
         confirmation_document: T.nilable(T::Hash[Symbol, T.untyped]),
         certificate_document: T.nilable(T::Hash[Symbol, T.untyped]),
         metadata: T.nilable(T::Hash[Symbol, T.untyped]),
         external_reference: String, # used for idempotency, if given, MUST be unique
         expand: T::Array[String],
+        client: Squake::Client,
       ).returns(Squake::Model::Purchase)
     end
-    def self.create(client:, pricing:, confirmation_document: nil, certificate_document: nil, metadata: nil, external_reference: SecureRandom.uuid, expand: [])
+    def self.create(pricing:, confirmation_document: nil, certificate_document: nil, metadata: nil, external_reference: SecureRandom.uuid, expand: [], client: Squake::Client.new)
       result = client.call(
         path: ENDPOINT,
         method: :post,


### PR DESCRIPTION
* added `Squake.configure`
* introduced global config allowig to omit the `client` from all service calls


we can now configure the gem in an initializer

```ruby
Squake.configure do |config|
  config.api_key = ENV.fetch('SQUAKE_API_KEY') # optional if ENV var `SQUAKE_API_KEY` is set
  config.sandbox_mode = true                   # set to `false` for production
  config.keep_alive_timeout = 30               # optional, default: 30
  config.logger = Logger.new($stdout)          # Set this to `Rails.logger` when using Rails
  config.enforced_api_base = nil               # for testing to e.g. point to a local server
end
```

thus explicitly sending a client/config to each request is now superfluous