### PR TITLE
Fix auth headers merge

### DIFF
--- a/lib/squake/client.rb
+++ b/lib/squake/client.rb
@@ -66,7 +66,7 @@ module Squake
         raise "Unrecognized HTTP method: #{method}. Expected one of: get, head, delete, post"
       end
 
-      headers.merge!(request_headers(api_key))
+      headers = request_headers(api_key).merge!(headers)
       query = query_params ? Util.encode_parameters(query_params) : nil
       body = body_params ? ::Oj.dump(body_params) : nil
       sanitized_path = path[0] == '/' ? path : "/#{path}"

--- a/lib/squake/client.rb
+++ b/lib/squake/client.rb
@@ -66,7 +66,7 @@ module Squake
         raise "Unrecognized HTTP method: #{method}. Expected one of: get, head, delete, post"
       end
 
-      request_headers(api_key).merge!(headers)
+      headers.merge!(request_headers(api_key))
       query = query_params ? Util.encode_parameters(query_params) : nil
       body = body_params ? ::Oj.dump(body_params) : nil
       sanitized_path = path[0] == '/' ? path : "/#{path}"


### PR DESCRIPTION
Headers are not including `Authorization` but we should also keep ability to overwrite it.

```rb
headers = { 'c' => 'd' }
=> {"c"=>"d"}
{'a' => 'b'}.merge!(headers)
=> {"a"=>"b", "c"=>"d"}
headers
=> {"c"=>"d"}



headers.merge!({'a' => 'b'})
=> {"c"=>"d", "a"=>"b"}
headers
=> {"c"=>"d", "a"=>"b"}
```