### PR TITLE
Fix Return class

### DIFF
--- a/lib/squake/return.rb
+++ b/lib/squake/return.rb
@@ -28,7 +28,7 @@ module Squake
 
     sig { returns(T::Boolean) }
     def success?
-      present?(@result)
+      blank?(@errors)
     end
 
     sig { returns(T::Boolean) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,16 @@
+# typed: false
+
+require 'squake'
+require 'byebug'
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = '.rspec_status'
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end

--- a/spec/squake/return_spec.rb
+++ b/spec/squake/return_spec.rb
@@ -1,0 +1,53 @@
+# typed: false
+
+require 'spec_helper'
+
+RSpec.describe Squake::Return do
+  subject(:return_object) { described_class.new(result: result, errors: errors) }
+
+  let(:result) { nil }
+  let(:errors) { nil }
+  let(:error) { Squake::Errors::APIErrorResult.new(code: :some_code, detail: 'some_detail') }
+
+  describe '#success?' do
+    [
+      { result: [], errors: nil },
+      { result: {}, errors: nil },
+      { result: nil, errors: [] },
+    ].each do |args|
+      context "when initialized with #{args}" do
+        let(:result) { args.fetch(:result) }
+        let(:errors) { args.fetch(:errors) }
+
+        it 'returns true' do
+          expect(return_object.success?).to be(true)
+        end
+      end
+    end
+  end
+
+  describe '#failed?' do
+    [
+      { result: [], errors: nil },
+      { result: {}, errors: nil },
+      { result: nil, errors: [] },
+    ].each do |args|
+      context "when initialized with #{args}" do
+        let(:result) { args.fetch(:result) }
+        let(:errors) { args.fetch(:errors) }
+
+        it 'returns false' do
+          expect(return_object.failed?).to be(false)
+        end
+      end
+    end
+
+    context 'when initialized with errors' do
+      let(:errors) { [error] }
+
+      it 'returns true' do
+        expect(return_object.failed?).to be(true)
+      end
+    end
+  end
+end

--- a/squake.gemspec
+++ b/squake.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sorbet-runtime'
 
   spec.add_development_dependency 'byebug'
+  spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop-dbl'
   spec.add_development_dependency 'spoom'
   spec.add_development_dependency 'tapioca'


### PR DESCRIPTION
### Motivation

Ensure that `Return` class initialised with `result: []` returns `true` when `#success?` called. Sometimes `/products` call can return empty array as response since no products can be accessible for a client, this should not result in a raise from `Return` class.

##### Before:

```rb
# response.body = []
products = response.body
result = Return.new(result: products)
result.success? # <--- returns false
```

##### After:

```rb
# response.body = []
products = response.body
result = Return.new(result: products)
result.success? # <--- returns true
```

