### PR TITLE
Add `/pricing` endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,9 @@ Layout/LineLength:
 Metrics/ClassLength:
   Max: 120
 
+Metrics/AbcSize:
+  Max: 37
+
 Style/IfUnlessModifier:
   Enabled: false
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,44 @@ else
 end
 ```
 
+### Get a price quote alone
+
+#### For a given carbon quantity
+
+```ruby
+Squake::Pricing.quote(
+  client: squake_client, # optional
+  carbon_quantity: 1000, # required
+  carbon_unit: 'kilogram', # optional, default: 'gram', other options: 'kilogram', 'tonne'
+  product_id: 'some_product_id', # required
+  expand: [], # optional, default: [], allowed values: 'product', 'price' to enrich the response
+)
+
+if context.success?
+  context.result # Squake::Model::Pricing
+else
+  context.errors # [Squake::Errors::APIErrorResult]
+end
+```
+
+#### For a given fixed total
+
+```ruby
+context = Squake::Pricing.quote(
+  client: squake_client, # optional
+  fixed_total: 1000, # required
+  currency: 'USD', # optional, default: 'EUR'
+  product_id: 'some_product_id', # required
+  expand: [], # optional, default: [], allowed values: 'product', 'price' to enrich the response
+)
+
+if context.success?
+  context.result # Squake::Model::Pricing
+else
+  context.errors # [Squake::Errors::APIErrorResult]
+end
+```
+
 ### Calculate emissions and include a price quote
 
 ```ruby

--- a/lib/squake/model/pricing.rb
+++ b/lib/squake/model/pricing.rb
@@ -49,7 +49,7 @@ module Squake
         Squake::Model::Pricing.new(
           id: response_body.fetch(:id),
           items: items,
-          carbon_quantity: response_body.fetch(:carbon_quantity).to_d,
+          carbon_quantity: BigDecimal(response_body.fetch(:carbon_quantity).to_s),
           carbon_unit: response_body.fetch(:carbon_unit),
           payment_link: response_body.fetch(:payment_link, nil),
           price: price,

--- a/lib/squake/pricing.rb
+++ b/lib/squake/pricing.rb
@@ -1,0 +1,55 @@
+# typed: strict
+# frozen_string_literal: true
+
+# https://docs-v2.squake.earth/group/endpoint-combined-calculation-pricing
+module Squake
+  class Pricing
+    extend T::Sig
+
+    ENDPOINT = T.let('/v2/pricing', String)
+
+    sig do
+      params(
+        product_id: String,
+        fixed_total: T.nilable(Numeric),
+        currency: String,
+        carbon_quantity: T.nilable(Numeric),
+        carbon_unit: T.nilable(String),
+        expand: T::Array[String],
+        client: Squake::Client,
+        request_id: T.nilable(String),
+      ).returns(Squake::Return[Squake::Model::Pricing])
+    end
+    def self.quote(
+      product_id:, fixed_total: nil, currency: 'EUR', carbon_quantity: nil, carbon_unit: 'gram', expand: [], client: Squake::Client.new, request_id: nil
+    )
+
+      result = client.call(
+        path: ENDPOINT,
+        method: :get,
+        headers: { 'X-Request-Id' => request_id }.compact,
+        params: {
+          product: product_id,
+          fixed_total: fixed_total,
+          currency: currency,
+          carbon_quantity: carbon_quantity,
+          carbon_unit: carbon_unit,
+          expand: expand,
+        },
+      )
+
+      if result.success?
+        pricing = Squake::Model::Pricing.from_api_response(
+          T.cast(result.body, T::Hash[Symbol, T.untyped]),
+        )
+        Return.new(result: pricing)
+      else
+        error = Squake::Errors::APIErrorResult.new(
+          code: :"api_error_#{result.code}",
+          detail: result.error_message,
+        )
+        Return.new(errors: [error])
+      end
+    end
+  end
+end

--- a/lib/squake/pricing.rb
+++ b/lib/squake/pricing.rb
@@ -1,8 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
-# https://docs-v2.squake.earth/group/endpoint-combined-calculation-pricing
 module Squake
+  # https://docs-v2.squake.earth/group/endpoint-pricing
   class Pricing
     extend T::Sig
 

--- a/lib/squake/pricing.rb
+++ b/lib/squake/pricing.rb
@@ -21,7 +21,8 @@ module Squake
       ).returns(Squake::Return[Squake::Model::Pricing])
     end
     def self.quote(
-      product_id:, fixed_total: nil, currency: 'EUR', carbon_quantity: nil, carbon_unit: 'gram', expand: [], client: Squake::Client.new, request_id: nil
+      product_id:, fixed_total: nil, currency: 'EUR', carbon_quantity: nil, carbon_unit: 'gram',
+      expand: [], client: Squake::Client.new, request_id: nil
     )
 
       result = client.call(

--- a/lib/squake/util.rb
+++ b/lib/squake/util.rb
@@ -11,13 +11,15 @@ module Squake
     # `&`).
     sig { params(params: T::Hash[Symbol, String]).returns(String) }
     def self.encode_parameters(params)
-      params.map { |k, v| "#{url_encode(k.to_s)}=#{url_encode(v)}" }.join('&')
+      params.map do |k, v|
+        "#{url_encode(k.to_s)}=#{url_encode(v.to_s)}" unless v.nil?
+      end.join('&')
     end
 
     # Encodes a string in a way that makes it suitable for use in a set of
     # query parameters in a URI or in a set of form parameters in a request
     # body.
-    sig { params(key: String).returns(String) }
+    sig { params(key: T.nilable(String)).returns(String) }
     def self.url_encode(key)
       CGI.escape(key.to_s).
         # Don't use strict form encoding by changing the square bracket control

--- a/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_carbon_quantity/when_invalid_request/behaves_like_failed_pricing_response/does_not_contain_result.yml
+++ b/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_carbon_quantity/when_invalid_request/behaves_like_failed_pricing_response/does_not_contain_result.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sandbox.squake.earth/v2/pricing?carbon_quantity=1000&carbon_unit=kilogram&currency=EUR&expand=%5B%5D&product=invalid
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer MOCK_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Tue, 17 Oct 2023 10:51:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Squake-Request-Id:
+      - req_sandbox_3bb0d619-7159-4198-8067-55431322dc44
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - req_sandbox_3bb0d619-7159-4198-8067-55431322dc44
+      X-Runtime:
+      - '0.010055'
+      Vary:
+      - Origin
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8177fcd5f9e348a7-LIS
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":"no_price_found","detail":null,"source":null}]}'
+  recorded_at: Tue, 17 Oct 2023 10:51:39 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_carbon_quantity/when_invalid_request/behaves_like_failed_pricing_response/returns_a_failed_response.yml
+++ b/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_carbon_quantity/when_invalid_request/behaves_like_failed_pricing_response/returns_a_failed_response.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sandbox.squake.earth/v2/pricing?carbon_quantity=1000&carbon_unit=kilogram&currency=EUR&expand=%5B%5D&product=invalid
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer MOCK_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Tue, 17 Oct 2023 10:51:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Squake-Request-Id:
+      - req_sandbox_24a47510-fe3d-4e1d-a8a7-67613e8489cb
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - req_sandbox_24a47510-fe3d-4e1d-a8a7-67613e8489cb
+      X-Runtime:
+      - '0.007881'
+      Vary:
+      - Origin
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8177fcd42ecc48a7-LIS
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":"no_price_found","detail":null,"source":null}]}'
+  recorded_at: Tue, 17 Oct 2023 10:51:39 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_carbon_quantity/when_invalid_request/behaves_like_failed_pricing_response/returns_errors.yml
+++ b/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_carbon_quantity/when_invalid_request/behaves_like_failed_pricing_response/returns_errors.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sandbox.squake.earth/v2/pricing?carbon_quantity=1000&carbon_unit=kilogram&currency=EUR&expand=%5B%5D&product=invalid
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer MOCK_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Tue, 17 Oct 2023 10:51:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Squake-Request-Id:
+      - req_sandbox_759aaa98-99d5-48d5-adc7-04674ffc8e48
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - req_sandbox_759aaa98-99d5-48d5-adc7-04674ffc8e48
+      X-Runtime:
+      - '0.007727'
+      Vary:
+      - Origin
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8177fcd5086748a7-LIS
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":"no_price_found","detail":null,"source":null}]}'
+  recorded_at: Tue, 17 Oct 2023 10:51:39 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_carbon_quantity/when_valid_request/behaves_like_successful_pricing_response/returns_a_pricing_object.yml
+++ b/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_carbon_quantity/when_valid_request/behaves_like_successful_pricing_response/returns_a_pricing_object.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sandbox.squake.earth/v2/pricing?carbon_quantity=1000&carbon_unit=kilogram&currency=EUR&expand=%5B%5D&product=product_026c41
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer MOCK_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Oct 2023 10:51:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Squake-Request-Id:
+      - req_sandbox_69d3ee29-cf28-4a36-be4a-46d8741636fa
+      Etag:
+      - W/"64117572f711f0acff7aec4c4edeb119"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - req_sandbox_69d3ee29-cf28-4a36-be4a-46d8741636fa
+      X-Runtime:
+      - '0.004210'
+      Vary:
+      - Origin
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8177fcd36d8548a7-LIS
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"eyJhbGciOiJIUzI1NiJ9.eyJwIjoicHJpY2VfWFNxTkQyIiwiY3EiOjEwMDAuMCwiY3UiOiJraWxvZ3JhbSIsInQiOjEyMzEsInRlIjoxMjMxLCJsIjoiZW4iLCJjIjoiRVVSIiwiZXhwIjoxNjk4NzQ5NDk5LCJmdCI6MCwicG0iOiJiYXRjaF9zZXR0bGVtZW50In0.I6Cb3Nl444pyDzLMFFHIukD1jKjk0giy3l-Qf6GSNMk","valid_until":"2023-10-31","carbon_quantity":1000.0,"carbon_unit":"kilogram","currency":"EUR","total":1231,"price":"price_XSqND2","product":"product_026c41"}'
+  recorded_at: Tue, 17 Oct 2023 10:51:39 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_carbon_quantity/when_valid_request/behaves_like_successful_pricing_response/returns_a_success_response.yml
+++ b/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_carbon_quantity/when_valid_request/behaves_like_successful_pricing_response/returns_a_success_response.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sandbox.squake.earth/v2/pricing?carbon_quantity=1000&carbon_unit=kilogram&currency=EUR&expand=%5B%5D&product=product_026c41
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer MOCK_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Oct 2023 10:51:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Squake-Request-Id:
+      - req_sandbox_c3bf3ede-21b5-4cf0-9969-7dbb35cb4b1d
+      Etag:
+      - W/"64117572f711f0acff7aec4c4edeb119"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - req_sandbox_c3bf3ede-21b5-4cf0-9969-7dbb35cb4b1d
+      X-Runtime:
+      - '0.004554'
+      Vary:
+      - Origin
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8177fcd2ac9f48a7-LIS
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"eyJhbGciOiJIUzI1NiJ9.eyJwIjoicHJpY2VfWFNxTkQyIiwiY3EiOjEwMDAuMCwiY3UiOiJraWxvZ3JhbSIsInQiOjEyMzEsInRlIjoxMjMxLCJsIjoiZW4iLCJjIjoiRVVSIiwiZXhwIjoxNjk4NzQ5NDk5LCJmdCI6MCwicG0iOiJiYXRjaF9zZXR0bGVtZW50In0.I6Cb3Nl444pyDzLMFFHIukD1jKjk0giy3l-Qf6GSNMk","valid_until":"2023-10-31","carbon_quantity":1000.0,"carbon_unit":"kilogram","currency":"EUR","total":1231,"price":"price_XSqND2","product":"product_026c41"}'
+  recorded_at: Tue, 17 Oct 2023 10:51:39 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_total/when_invalid_request/behaves_like_failed_pricing_response/does_not_contain_result.yml
+++ b/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_total/when_invalid_request/behaves_like_failed_pricing_response/does_not_contain_result.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sandbox.squake.earth/v2/pricing?carbon_unit=gram&currency=EUR&expand=%5B%5D&fixed_total=1000&product=invalid
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer MOCK_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Tue, 17 Oct 2023 10:51:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Squake-Request-Id:
+      - req_sandbox_127e5355-6ec6-435f-be75-430f3905aa83
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - req_sandbox_127e5355-6ec6-435f-be75-430f3905aa83
+      X-Runtime:
+      - '0.007346'
+      Vary:
+      - Origin
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8177fcd9c83448a7-LIS
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":"no_price_found","detail":null,"source":null}]}'
+  recorded_at: Tue, 17 Oct 2023 10:51:40 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_total/when_invalid_request/behaves_like_failed_pricing_response/returns_a_failed_response.yml
+++ b/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_total/when_invalid_request/behaves_like_failed_pricing_response/returns_a_failed_response.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sandbox.squake.earth/v2/pricing?carbon_unit=gram&currency=EUR&expand=%5B%5D&fixed_total=1000&product=invalid
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer MOCK_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Tue, 17 Oct 2023 10:51:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Squake-Request-Id:
+      - req_sandbox_0f7e5483-7e0b-4034-b645-5a88f6288440
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - req_sandbox_0f7e5483-7e0b-4034-b645-5a88f6288440
+      X-Runtime:
+      - '0.007650'
+      Vary:
+      - Origin
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8177fcd85dc948a7-LIS
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":"no_price_found","detail":null,"source":null}]}'
+  recorded_at: Tue, 17 Oct 2023 10:51:40 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_total/when_invalid_request/behaves_like_failed_pricing_response/returns_errors.yml
+++ b/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_total/when_invalid_request/behaves_like_failed_pricing_response/returns_errors.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sandbox.squake.earth/v2/pricing?carbon_unit=gram&currency=EUR&expand=%5B%5D&fixed_total=1000&product=invalid
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer MOCK_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Tue, 17 Oct 2023 10:51:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Squake-Request-Id:
+      - req_sandbox_db29992f-4875-4963-8800-f315b6b25601
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - req_sandbox_db29992f-4875-4963-8800-f315b6b25601
+      X-Runtime:
+      - '0.008148'
+      Vary:
+      - Origin
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8177fcd90edf48a7-LIS
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":"no_price_found","detail":null,"source":null}]}'
+  recorded_at: Tue, 17 Oct 2023 10:51:40 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_total/when_valid_request/behaves_like_successful_pricing_response/returns_a_pricing_object.yml
+++ b/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_total/when_valid_request/behaves_like_successful_pricing_response/returns_a_pricing_object.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sandbox.squake.earth/v2/pricing?carbon_unit=gram&currency=EUR&expand=%5B%5D&fixed_total=1000&product=product_026c41
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer MOCK_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Oct 2023 10:51:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Squake-Request-Id:
+      - req_sandbox_bc9edee9-f218-47af-b463-53a22126132c
+      Etag:
+      - W/"124127767235b3a18e00acb81d6ec495"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - req_sandbox_bc9edee9-f218-47af-b463-53a22126132c
+      X-Runtime:
+      - '0.004184'
+      Vary:
+      - Origin
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8177fcd78c7648a7-LIS
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"eyJhbGciOiJIUzI1NiJ9.eyJwIjoicHJpY2VfWFNxTkQyIiwiY3EiOjgxMjM0OCwiY3UiOiJncmFtIiwidCI6MTAwMCwidGUiOjEwMDAsImwiOiJlbiIsImMiOiJFVVIiLCJleHAiOjE2OTg3NDk1MDAsImZ0IjoxLCJwbSI6ImJhdGNoX3NldHRsZW1lbnQifQ.Ox_yHFHPXvIY7JTcJVEhBfBiJ6CwOxgtfukL5-B3zwk","valid_until":"2023-10-31","carbon_quantity":812348,"carbon_unit":"gram","currency":"EUR","total":1000,"price":"price_XSqND2","product":"product_026c41"}'
+  recorded_at: Tue, 17 Oct 2023 10:51:40 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_total/when_valid_request/behaves_like_successful_pricing_response/returns_a_success_response.yml
+++ b/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_fixed_total/when_valid_request/behaves_like_successful_pricing_response/returns_a_success_response.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sandbox.squake.earth/v2/pricing?carbon_unit=gram&currency=EUR&expand=%5B%5D&fixed_total=1000&product=product_026c41
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer MOCK_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Oct 2023 10:51:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Squake-Request-Id:
+      - req_sandbox_9b7cace7-06cd-4aaa-8520-7f199d53dcd4
+      Etag:
+      - W/"124127767235b3a18e00acb81d6ec495"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - req_sandbox_9b7cace7-06cd-4aaa-8520-7f199d53dcd4
+      X-Runtime:
+      - '0.004271'
+      Vary:
+      - Origin
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8177fcd6db7248a7-LIS
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"eyJhbGciOiJIUzI1NiJ9.eyJwIjoicHJpY2VfWFNxTkQyIiwiY3EiOjgxMjM0OCwiY3UiOiJncmFtIiwidCI6MTAwMCwidGUiOjEwMDAsImwiOiJlbiIsImMiOiJFVVIiLCJleHAiOjE2OTg3NDk1MDAsImZ0IjoxLCJwbSI6ImJhdGNoX3NldHRsZW1lbnQifQ.Ox_yHFHPXvIY7JTcJVEhBfBiJ6CwOxgtfukL5-B3zwk","valid_until":"2023-10-31","carbon_quantity":812348,"carbon_unit":"gram","currency":"EUR","total":1000,"price":"price_XSqND2","product":"product_026c41"}'
+  recorded_at: Tue, 17 Oct 2023 10:51:39 GMT
+recorded_with: VCR 6.2.0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ require 'squake'
 require 'byebug'
 require 'vcr'
 
+Dir.glob('./spec/support/**/*.rb').each { require(_1) }
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
@@ -25,6 +27,6 @@ end
 
 SQUAKE_API_KEY = 'MOCK_API_KEY'
 def squake_client
-  config = Squake::Config.new(api_key: SQUAKE_API_KEY)
+  config = Squake::Config.new(api_key: SQUAKE_API_KEY, sandbox_mode: true)
   Squake::Client.new(config: config)
 end

--- a/spec/squake/pricing_spec.rb
+++ b/spec/squake/pricing_spec.rb
@@ -1,0 +1,50 @@
+# typed: false
+
+require 'spec_helper'
+
+RSpec.describe Squake::Pricing, :vcr do
+  let(:product_id) { 'product_026c41' }
+
+  describe '#quote' do
+    context 'when requesting with fixed carbon_quantity' do
+      subject(:pricing) do
+        described_class.quote(
+          client: squake_client,
+          carbon_quantity: 1000,
+          carbon_unit: 'kilogram',
+          product_id: product_id,
+        )
+      end
+
+      context 'when valid request' do
+        it_behaves_like 'successful pricing response'
+      end
+
+      context 'when invalid request' do
+        let(:product_id) { 'invalid' }
+
+        it_behaves_like 'failed pricing response'
+      end
+    end
+
+    context 'when requesting with fixed total' do
+      subject(:pricing) do
+        described_class.quote(
+          client: squake_client,
+          fixed_total: 1000,
+          product_id: product_id,
+        )
+      end
+
+      context 'when valid request' do
+        it_behaves_like 'successful pricing response'
+      end
+
+      context 'when invalid request' do
+        let(:product_id) { 'invalid' }
+
+        it_behaves_like 'failed pricing response'
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/failed_pricing_response.rb
+++ b/spec/support/shared_examples/failed_pricing_response.rb
@@ -1,0 +1,12 @@
+# typed: false
+# frozen_string_literal: true
+
+RSpec.shared_examples_for 'failed pricing response' do
+  it 'returns a failed response' do
+    expect(pricing.success?).to be(false)
+  end
+
+  it 'returns errors' do
+    expect(pricing.errors).not_to be_empty
+  end
+end

--- a/spec/support/shared_examples/successful_pricing_response.rb
+++ b/spec/support/shared_examples/successful_pricing_response.rb
@@ -1,0 +1,12 @@
+# typed: false
+# frozen_string_literal: true
+
+RSpec.shared_examples_for 'successful pricing response' do
+  it 'returns a success response' do
+    expect(pricing.success?).to be(true)
+  end
+
+  it 'returns a pricing object' do
+    expect(pricing.result).to be_a(Squake::Model::Pricing)
+  end
+end


### PR DESCRIPTION
### Motivation

We're missing this (https://docs-v2.squake.earth/group/endpoint-pricing) part of API in this gem so let's implement it. If you don't need to calculate emissions, you can now simply pass either `carbon_quantity` or `fixed_total` you want to spend on selected product. Example usage is added to the readme.