### PR TITLE
Add `payment_link_return_url` to `Squake::CalculationWithPricing` - #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,12 @@ end
 
 ```ruby
 Squake::Pricing.quote(
-  client: squake_client, # optional
-  carbon_quantity: 1000, # required
-  carbon_unit: 'kilogram', # optional, default: 'gram', other options: 'kilogram', 'tonne'
-  product_id: 'some_product_id', # required
-  expand: [], # optional, default: [], allowed values: 'product', 'price' to enrich the response
+  client: squake_client,                           # optional
+  carbon_quantity: 1000,                           # required
+  carbon_unit: 'kilogram',                         # optional, default: 'gram', other options: 'kilogram', 'tonne'
+  product_id: 'some_product_id',                   # required
+  expand: [],                                      # optional, default: [], allowed values: 'product', 'price' to enrich the response
+  payment_link_return_url: 'https://squake.earth', # optional, default: nil
 )
 
 if context.success?
@@ -164,8 +165,8 @@ context = Squake::CalculationWithPricing.quote(
   currency: 'EUR',                                 # optional, default: 'EUR'
   carbon_unit: 'gram',                             # optional, default: 'gram', other options: 'kilogram', 'tonne'
   expand: [],                                      # optional, default: [], allowed values: 'items', 'product', 'price' to enrich the response
-  client: client,                                  # optional
   payment_link_return_url: 'https://squake.earth', # optional, default: nil
+  client: client,                                  # optional
 )
 
 if context.success?

--- a/README.md
+++ b/README.md
@@ -159,12 +159,13 @@ end
 
 ```ruby
 context = Squake::CalculationWithPricing.quote(
-  items: items,          # required
-  product: 'product-id', # required
-  currency: 'EUR',       # optional, default: 'EUR'
-  carbon_unit: 'gram',   # optional, default: 'gram', other options: 'kilogram', 'tonne'
-  expand: [],            # optional, default: [], allowed values: 'items', 'product', 'price' to enrich the response
-  client: client,        # optional
+  items: items,                                    # required
+  product: 'product-id',                           # required
+  currency: 'EUR',                                 # optional, default: 'EUR'
+  carbon_unit: 'gram',                             # optional, default: 'gram', other options: 'kilogram', 'tonne'
+  expand: [],                                      # optional, default: [], allowed values: 'items', 'product', 'price' to enrich the response
+  client: client,                                  # optional
+  payment_link_return_url: 'https://squake.earth', # optional, default: nil
 )
 
 if context.success?

--- a/lib/squake/calculation_with_pricing.rb
+++ b/lib/squake/calculation_with_pricing.rb
@@ -15,12 +15,13 @@ module Squake
         currency: String,
         carbon_unit: String,
         expand: T::Array[String],
+        payment_link_return_url: T.nilable(String),
         client: Squake::Client,
         request_id: T.nilable(String),
       ).returns(Squake::Return[Squake::Model::Pricing])
     end
     def self.quote(
-      items:, product:, currency: 'EUR', carbon_unit: 'gram', expand: [], client: Squake::Client.new, request_id: nil
+      items:, product:, currency: 'EUR', carbon_unit: 'gram', expand: [], payment_link_return_url: nil, client: Squake::Client.new, request_id: nil
     )
       # @TODO: add typed objects for all possible items. Until then, we allow either a Hash or a T::Struct
       items = items.map do |item|
@@ -37,6 +38,7 @@ module Squake
           currency: currency,
           carbon_unit: carbon_unit,
           expand: expand,
+          payment_link_return_url: payment_link_return_url,
         },
       )
 

--- a/lib/squake/pricing.rb
+++ b/lib/squake/pricing.rb
@@ -16,13 +16,14 @@ module Squake
         carbon_quantity: T.nilable(Numeric),
         carbon_unit: T.nilable(String),
         expand: T::Array[String],
+        payment_link_return_url: T.nilable(String),
         client: Squake::Client,
         request_id: T.nilable(String),
       ).returns(Squake::Return[Squake::Model::Pricing])
     end
     def self.quote(
       product_id:, fixed_total: nil, currency: 'EUR', carbon_quantity: nil, carbon_unit: 'gram',
-      expand: [], client: Squake::Client.new, request_id: nil
+      expand: [], payment_link_return_url: nil, client: Squake::Client.new, request_id: nil
     )
 
       result = client.call(
@@ -36,6 +37,7 @@ module Squake
           carbon_quantity: carbon_quantity,
           carbon_unit: carbon_unit,
           expand: expand,
+          payment_link_return_url: payment_link_return_url,
         },
       )
 


### PR DESCRIPTION
#### Summary

Add `payment_link_return_url` to `Squake::CalculationWithPricing` 

#### Motivation

closes https://github.com/squake-earth/squake-ruby/issues/11