### PR TITLE
Add `payment_method` option 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,4 +50,4 @@ Metrics/MethodLength:
   CountAsOne: ['array', 'heredoc', 'method_call']
 
 Metrics/ParameterLists:
-  Max: 8
+  Max: 10

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,6 +10,11 @@
 # Configuration parameters: EnforcedStyle, AllowedGems, Include.
 # SupportedStyles: Gemfile, gems.rb, gemspec
 # Include: **/*.gemspec, **/Gemfile, **/gems.rb
+AllCops:
+  Exclude:
+    - 'squake.gemspec'
+    - 'bin/**/*'
+
 Gemspec/DevelopmentDependencies:
   Exclude:
     - 'squake.gemspec'

--- a/lib/squake/calculation_with_pricing.rb
+++ b/lib/squake/calculation_with_pricing.rb
@@ -16,13 +16,14 @@ module Squake
         carbon_unit: String,
         expand: T::Array[String],
         payment_link_return_url: T.nilable(String),
+        payment_method: T.nilable(Squake::Model::PaymentMethod),
         client: Squake::Client,
         request_id: T.nilable(String),
       ).returns(Squake::Return[Squake::Model::Pricing])
     end
     def self.quote(
       items:, product:, currency: 'EUR', carbon_unit: 'gram',
-      expand: [], payment_link_return_url: nil, client: Squake::Client.new, request_id: nil
+      expand: [], payment_method: nil, payment_link_return_url: nil, client: Squake::Client.new, request_id: nil
     )
       # @TODO: add typed objects for all possible items. Until then, we allow either a Hash or a T::Struct
       items = items.map do |item|
@@ -40,6 +41,7 @@ module Squake
           carbon_unit: carbon_unit,
           expand: expand,
           payment_link_return_url: payment_link_return_url,
+          payment_method: payment_method.serialize,
         },
       )
 

--- a/lib/squake/calculation_with_pricing.rb
+++ b/lib/squake/calculation_with_pricing.rb
@@ -23,7 +23,8 @@ module Squake
     end
     def self.quote(
       items:, product:, currency: 'EUR', carbon_unit: 'gram',
-      expand: [], payment_method: nil, payment_link_return_url: nil, client: Squake::Client.new, request_id: nil
+      expand: [], payment_method: nil, payment_link_return_url: nil,
+      client: Squake::Client.new, request_id: nil
     )
       # @TODO: add typed objects for all possible items. Until then, we allow either a Hash or a T::Struct
       items = items.map do |item|

--- a/lib/squake/calculation_with_pricing.rb
+++ b/lib/squake/calculation_with_pricing.rb
@@ -23,7 +23,7 @@ module Squake
     end
     def self.quote(
       items:, product:, currency: 'EUR', carbon_unit: 'gram',
-      expand: [], payment_method: nil, payment_link_return_url: nil,
+      expand: [], payment_link_return_url: nil, payment_method: nil,
       client: Squake::Client.new, request_id: nil
     )
       # @TODO: add typed objects for all possible items. Until then, we allow either a Hash or a T::Struct
@@ -42,7 +42,7 @@ module Squake
           carbon_unit: carbon_unit,
           expand: expand,
           payment_link_return_url: payment_link_return_url,
-          payment_method: payment_method.serialize,
+          payment_method: payment_method&.serialize,
         },
       )
 

--- a/lib/squake/model/payment_method.rb
+++ b/lib/squake/model/payment_method.rb
@@ -1,0 +1,15 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Squake
+  module Model
+    class PaymentMethod < T::Enum
+      extend T::Sig
+
+      enums do
+        BatchSettlement = new('batch_settlement')
+        Stripe = new('stripe')
+      end
+    end
+  end
+end

--- a/lib/squake/pricing.rb
+++ b/lib/squake/pricing.rb
@@ -22,11 +22,11 @@ module Squake
         request_id: T.nilable(String),
       ).returns(Squake::Return[Squake::Model::Pricing])
     end
-    def self.quote( # rubocop:disable Metrics/ParameterLists
+    def self.quote(
       product_id:, fixed_total: nil, currency: 'EUR', carbon_quantity: nil, carbon_unit: 'gram',
-      expand: [], payment_link_return_url: nil, payment_method: nil, client: Squake::Client.new, request_id: nil
+      expand: [], payment_link_return_url: nil, payment_method: nil,
+      client: Squake::Client.new, request_id: nil
     )
-
       result = client.call(
         path: ENDPOINT,
         method: :get,

--- a/lib/squake/pricing.rb
+++ b/lib/squake/pricing.rb
@@ -17,13 +17,14 @@ module Squake
         carbon_unit: T.nilable(String),
         expand: T::Array[String],
         payment_link_return_url: T.nilable(String),
+        payment_method: T.nilable(Squake::Model::PaymentMethod),
         client: Squake::Client,
         request_id: T.nilable(String),
       ).returns(Squake::Return[Squake::Model::Pricing])
     end
     def self.quote( # rubocop:disable Metrics/ParameterLists
       product_id:, fixed_total: nil, currency: 'EUR', carbon_quantity: nil, carbon_unit: 'gram',
-      expand: [], payment_link_return_url: nil, client: Squake::Client.new, request_id: nil
+      expand: [], payment_link_return_url: nil, payment_method: nil, client: Squake::Client.new, request_id: nil
     )
 
       result = client.call(
@@ -38,6 +39,7 @@ module Squake
           carbon_unit: carbon_unit,
           expand: expand,
           payment_link_return_url: payment_link_return_url,
+          payment_method: payment_method&.serialize,
         },
       )
 

--- a/lib/squake/util.rb
+++ b/lib/squake/util.rb
@@ -14,11 +14,11 @@ module Squake
       params.map do |k, v|
         case v
         when Array
-          v.map { |e| "#{url_encode(k.to_s)}[]=#{url_encode(e.to_s)}" }.join('&')
+          v.map { "#{url_encode(k.to_s)}[]=#{url_encode(_1.to_s)}" }
         else
           "#{url_encode(k.to_s)}=#{url_encode(v.to_s)}" unless v.nil?
         end
-      end.join('&')
+      end.flatten.compact.join('&')
     end
 
     # Encodes a string in a way that makes it suitable for use in a set of

--- a/lib/squake/version.rb
+++ b/lib/squake/version.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module Squake

--- a/sorbet/tapioca/require.rb
+++ b/sorbet/tapioca/require.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require 'byebug'

--- a/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_payment_method/behaves_like_successful_pricing_response/returns_a_pricing_object.yml
+++ b/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_payment_method/behaves_like_successful_pricing_response/returns_a_pricing_object.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sandbox.squake.earth/v2/pricing?carbon_unit=gram&currency=EUR&fixed_total=1000&payment_method=stripe&product=product_N7TnHY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer MOCK_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 13 Jan 2025 11:36:54 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"b340217520cee10f56b86b7f61aba95a"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Squake-Request-Id:
+      - req_sandbox_4281f13f-a960-4336-975c-7c2fe91cd317
+      X-Request-Id:
+      - req_sandbox_4281f13f-a960-4336-975c-7c2fe91cd317
+      X-Runtime:
+      - '0.008090'
+      Vary:
+      - Origin
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9015175a6a67e296-BEG
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"eyJhbGciOiJIUzI1NiJ9.eyJwIjoicHJpY2VfeThnalpZIiwiY3EiOjg4NzQyLCJjdSI6ImdyYW0iLCJ0IjoxMDAwLCJ0ZSI6MTAwMCwibCI6ImVuIiwiYyI6IkVVUiIsImV4cCI6MTczNzk3NzgxNCwiZnQiOjEsInBtIjoic3RyaXBlIn0.iLDkhWK1BWpAJGSzzGwgMizOWdNJj_obVGwbjayMgF8","valid_until":"2025-01-27","carbon_quantity":88742,"carbon_unit":"gram","currency":"EUR","total":1000,"price":"price_y8gjZY","product":"product_N7TnHY","payment_link":"https://checkout.sandbox.squake.earth?t=eyJhbGciOiJIUzI1NiJ9.eyJwIjoicHJpY2VfeThnalpZIiwiY3EiOjg4NzQyLCJjdSI6ImdyYW0iLCJ0IjoxMDAwLCJ0ZSI6MTAwMCwibCI6ImVuIiwiYyI6IkVVUiIsImV4cCI6MTczNzk3NzgxNCwiZnQiOjEsInBtIjoic3RyaXBlIn0.iLDkhWK1BWpAJGSzzGwgMizOWdNJj_obVGwbjayMgF8"}'
+  recorded_at: Mon, 13 Jan 2025 11:36:54 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_payment_method/behaves_like_successful_pricing_response/returns_a_success_response.yml
+++ b/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_payment_method/behaves_like_successful_pricing_response/returns_a_success_response.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sandbox.squake.earth/v2/pricing?carbon_unit=gram&currency=EUR&fixed_total=1000&payment_method=stripe&product=product_N7TnHY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer MOCK_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 13 Jan 2025 11:36:54 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"b340217520cee10f56b86b7f61aba95a"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Squake-Request-Id:
+      - req_sandbox_92231cb7-283d-4b88-92eb-f3df607b631b
+      X-Request-Id:
+      - req_sandbox_92231cb7-283d-4b88-92eb-f3df607b631b
+      X-Runtime:
+      - '0.007111'
+      Vary:
+      - Origin
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 901517599e74e298-BEG
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"eyJhbGciOiJIUzI1NiJ9.eyJwIjoicHJpY2VfeThnalpZIiwiY3EiOjg4NzQyLCJjdSI6ImdyYW0iLCJ0IjoxMDAwLCJ0ZSI6MTAwMCwibCI6ImVuIiwiYyI6IkVVUiIsImV4cCI6MTczNzk3NzgxNCwiZnQiOjEsInBtIjoic3RyaXBlIn0.iLDkhWK1BWpAJGSzzGwgMizOWdNJj_obVGwbjayMgF8","valid_until":"2025-01-27","carbon_quantity":88742,"carbon_unit":"gram","currency":"EUR","total":1000,"price":"price_y8gjZY","product":"product_N7TnHY","payment_link":"https://checkout.sandbox.squake.earth?t=eyJhbGciOiJIUzI1NiJ9.eyJwIjoicHJpY2VfeThnalpZIiwiY3EiOjg4NzQyLCJjdSI6ImdyYW0iLCJ0IjoxMDAwLCJ0ZSI6MTAwMCwibCI6ImVuIiwiYyI6IkVVUiIsImV4cCI6MTczNzk3NzgxNCwiZnQiOjEsInBtIjoic3RyaXBlIn0.iLDkhWK1BWpAJGSzzGwgMizOWdNJj_obVGwbjayMgF8"}'
+  recorded_at: Mon, 13 Jan 2025 11:36:53 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_payment_method/contains_payment_link.yml
+++ b/spec/fixtures/vcr_cassettes/Squake_Pricing/_quote/when_requesting_with_payment_method/contains_payment_link.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sandbox.squake.earth/v2/pricing?carbon_unit=gram&currency=EUR&fixed_total=1000&payment_method=stripe&product=product_N7TnHY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer MOCK_API_KEY
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 13 Jan 2025 11:36:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"2e3290e915ce81529df9fd0e420d5b85"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Squake-Request-Id:
+      - req_sandbox_dc04db4c-a89e-4a69-bb84-c5e587170d94
+      X-Request-Id:
+      - req_sandbox_dc04db4c-a89e-4a69-bb84-c5e587170d94
+      X-Runtime:
+      - '0.012076'
+      Vary:
+      - Origin
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9015175888abe290-BEG
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"eyJhbGciOiJIUzI1NiJ9.eyJwIjoicHJpY2VfeThnalpZIiwiY3EiOjg4NzQyLCJjdSI6ImdyYW0iLCJ0IjoxMDAwLCJ0ZSI6MTAwMCwibCI6ImVuIiwiYyI6IkVVUiIsImV4cCI6MTczNzk3NzgxMywiZnQiOjEsInBtIjoic3RyaXBlIn0.sLlWAHbpPa_LlIKmElMHiABkCC-HjXw7MOcVuPa9WGA","valid_until":"2025-01-27","carbon_quantity":88742,"carbon_unit":"gram","currency":"EUR","total":1000,"price":"price_y8gjZY","product":"product_N7TnHY","payment_link":"https://checkout.sandbox.squake.earth?t=eyJhbGciOiJIUzI1NiJ9.eyJwIjoicHJpY2VfeThnalpZIiwiY3EiOjg4NzQyLCJjdSI6ImdyYW0iLCJ0IjoxMDAwLCJ0ZSI6MTAwMCwibCI6ImVuIiwiYyI6IkVVUiIsImV4cCI6MTczNzk3NzgxMywiZnQiOjEsInBtIjoic3RyaXBlIn0.sLlWAHbpPa_LlIKmElMHiABkCC-HjXw7MOcVuPa9WGA"}'
+  recorded_at: Mon, 13 Jan 2025 11:36:53 GMT
+recorded_with: VCR 6.2.0

--- a/spec/squake/pricing_spec.rb
+++ b/spec/squake/pricing_spec.rb
@@ -72,5 +72,26 @@ RSpec.describe Squake::Pricing, :vcr do
         it_behaves_like 'failed pricing response'
       end
     end
+
+    context 'when requesting with payment method' do
+      let(:product_id) { 'product_N7TnHY' }
+
+      subject(:pricing) do
+        described_class.quote(
+          client: squake_client,
+          product_id: product_id,
+          payment_method: Squake::Model::PaymentMethod::Stripe,
+          fixed_total: 1000,
+        )
+      end
+
+      it_behaves_like 'successful pricing response'
+
+      it 'contains payment link' do
+        expect(pricing.result.payment_link).to be_a(String)
+        expect(pricing.result.payment_link).to include('checkout.sandbox.squake.earth')
+      end
+    end
   end
 end
+

--- a/spec/squake/pricing_spec.rb
+++ b/spec/squake/pricing_spec.rb
@@ -74,8 +74,6 @@ RSpec.describe Squake::Pricing, :vcr do
     end
 
     context 'when requesting with payment method' do
-      let(:product_id) { 'product_N7TnHY' }
-
       subject(:pricing) do
         described_class.quote(
           client: squake_client,
@@ -84,6 +82,8 @@ RSpec.describe Squake::Pricing, :vcr do
           fixed_total: 1000,
         )
       end
+
+      let(:product_id) { 'product_N7TnHY' }
 
       it_behaves_like 'successful pricing response'
 
@@ -94,4 +94,3 @@ RSpec.describe Squake::Pricing, :vcr do
     end
   end
 end
-

--- a/squake.gemspec
+++ b/squake.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name                  = 'squake'
   spec.version               = Squake::VERSION
   spec.summary               = 'The industry solution for sustainable travel and logistics.'
-  spec.description           = 'This gem provides an interface for the SQUAKE API to calculate and compensate carbon emissions.' # rubocop:disable Layout/LineLength
+  spec.description           = 'This gem provides an interface for the SQUAKE API to calculate and compensate carbon emissions.'
   spec.author                = 'SQUAKE'
   spec.email                 = 'oss@squake.earth'
   spec.files                 = Dir[

--- a/squake.gemspec
+++ b/squake.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'base64' # removed in Ruby 3.4, subdependency of VCR
   spec.add_development_dependency 'byebug'
+  spec.add_development_dependency 'logger'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop-dbl'
   spec.add_development_dependency 'spoom'


### PR DESCRIPTION
1. Our API supports `payment_method` option, this PR adds an ability to pass it to the request. Both `Squake::Pricing` and 
`Squake::CalculationWithPricing` do support that option. 

2. This PR is also fixes the way we generate URL query params,

before: `/v2/pricing?product=product_026c41&&currency=EUR&carbon_quantity=1000&carbon_unit=kilogram&&`
after: `/v2/pricing?product=product_026c41&currency=EUR&carbon_quantity=1000&carbon_unit=kilogram`
